### PR TITLE
Extract ISpi for for unit testing

### DIFF
--- a/SPIClient/ISpi.cs
+++ b/SPIClient/ISpi.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace SPIClient
+{
+    public interface ISpi
+    {
+        SpiFlow CurrentFlow { get; }
+        PairingFlowState CurrentPairingFlowState { get; }
+        SpiStatus CurrentStatus { get; }
+        TransactionFlowState CurrentTxFlowState { get; }
+
+        event EventHandler<PairingFlowState> PairingFlowStateChanged;
+        event EventHandler<Secrets> SecretsChanged;
+        event EventHandler<SpiStatusEventArgs> StatusChanged;
+        event EventHandler<TransactionFlowState> TxFlowStateChanged;
+
+        MidTxResult AcceptSignature(bool accepted);
+        bool AckFlowEndedAndBackToIdle();
+        MidTxResult CancelTransaction();
+        void Dispose();
+        SpiPayAtTable EnablePayAtTable();
+        SpiPreauth EnablePreauth();
+        Message.SuccessState GltMatch(GetLastTransactionResponse gltResponse, string posRefId);
+        Message.SuccessState GltMatch(GetLastTransactionResponse gltResponse, TransactionType expectedType, int expectedAmount, DateTime requestTime, string posRefId);
+        InitiateTxResult InitiateCashoutOnlyTx(string posRefId, int amountCents);
+        InitiateTxResult InitiateGetLastTx();
+        InitiateTxResult InitiateMotoPurchaseTx(string posRefId, int amountCents);
+        InitiateTxResult InitiatePurchaseTx(string posRefId, int amountCents);
+        InitiateTxResult InitiatePurchaseTxV2(string posRefId, int purchaseAmount, int tipAmount, int cashoutAmount, bool promptForCashout);
+        InitiateTxResult InitiateRecovery(string posRefId, TransactionType txType);
+        InitiateTxResult InitiateRefundTx(string posRefId, int amountCents);
+        InitiateTxResult InitiateSettlementEnquiry(string posRefId);
+        InitiateTxResult InitiateSettleTx(string posRefId);
+        bool Pair();
+        void PairingCancel();
+        void PairingConfirmCode();
+        bool SetEftposAddress(string address);
+        bool SetPosId(string posId);
+        void Start();
+        SubmitAuthCodeResult SubmitAuthCode(string authCode);
+        bool Unpair();
+    }
+}

--- a/SPIClient/ISpi.cs
+++ b/SPIClient/ISpi.cs
@@ -4,6 +4,7 @@ namespace SPIClient
 {
     public interface ISpi
     {
+        SpiConfig Config { get; }
         SpiFlow CurrentFlow { get; }
         PairingFlowState CurrentPairingFlowState { get; }
         SpiStatus CurrentStatus { get; }

--- a/SPIClient/Spi.cs
+++ b/SPIClient/Spi.cs
@@ -12,7 +12,7 @@ namespace SPIClient
     [ComVisible(true)]
     [Guid("908B84A9-FB9E-42FF-ABD7-69FACB2A84D8")]
     [ClassInterface(ClassInterfaceType.AutoDual)]
-    public class Spi : IDisposable
+    public class Spi : IDisposable, ISpi
     {
         #region Public Properties and Events
 

--- a/SPIClient/Spi.cs
+++ b/SPIClient/Spi.cs
@@ -16,7 +16,7 @@ namespace SPIClient
     {
         #region Public Properties and Events
 
-        public readonly SpiConfig Config = new SpiConfig();
+        public SpiConfig Config { get; } = new SpiConfig();
 
         /// <summary>
         /// The Current Status of this Spi instance. Unpaired, PairedConnecting or PairedConnected.


### PR DESCRIPTION
Hi AssemblyPayments,

If we uses the ```Spi``` class directly,  we can't do unit testing beacause the methods and events of ```Spi``` is not virtual and it can't be mocked.  

So we need a ```ISpi```  to simplify unit testing,  otherwise we have to wirte an extra layer to wrap the ```Spi``` class